### PR TITLE
Fix uncaught ReferenceError: process is not define

### DIFF
--- a/with-mongoose/main.ts
+++ b/with-mongoose/main.ts
@@ -1,3 +1,4 @@
+import "https://deno.land/std/node/global.ts";
 import mongoose from "npm:mongoose@^6.7";
 import Dinosaur from "./model/Dinosaur.ts";
 


### PR DESCRIPTION
error: Uncaught ReferenceError: process is not defined.

missing `import "https://deno.land/std/node/global.ts";`