### PR TITLE
Fix react-dom import specifier

### DIFF
--- a/with-react/vite.config.mjs
+++ b/with-react/vite.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from "npm:vite@^3.1.3";
 import react from "npm:@vitejs/plugin-react@^2.1";
 
 import "npm:react@^18.2";
-import "npm:react-dom/client@^18.2";
+import "npm:react-dom@^18.2/client";
 import "npm:react-router-dom@^6.4";
 
 // https://vitejs.dev/config/


### PR DESCRIPTION
The current import cause to this error on `deno task dev`:
```sh
TypeError: Invalid package specifier 'npm:react-dom/client@^18.2'. 
  Did you mean to write 'npm:react-dom@^18.2/client'?
```