### PR TITLE
fix(with-nuxt): a few changes to make it more idiomatic

### DIFF
--- a/with-nuxt/app.vue
+++ b/with-nuxt/app.vue
@@ -1,15 +1,13 @@
 <template>
-  <NuxtLayout>
-    <div>
-      <nav class="p-4 bg-gray-100">
-        <NuxtLink to="/" class="text-blue-600 hover:text-blue-800">
-          Dinosaur Encyclopedia
-        </NuxtLink>
-      </nav>
+  <div>
+    <nav class="p-4 bg-gray-100">
+      <NuxtLink to="/" class="text-blue-600 hover:text-blue-800">
+        Dinosaur Encyclopedia
+      </NuxtLink>
+    </nav>
 
-      <div class="container mx-auto p-4">
-        <NuxtPage />
-      </div>
+    <div class="container mx-auto p-4">
+      <NuxtPage />
     </div>
-  </NuxtLayout>
+  </div>
 </template>

--- a/with-nuxt/nuxt.config.ts
+++ b/with-nuxt/nuxt.config.ts
@@ -2,21 +2,14 @@ import { defineNuxtConfig } from "nuxt/config";
 
 export default defineNuxtConfig({
   devtools: { enabled: true },
-  ssr: false,
 
   nitro: {
     preset: "deno",
   },
 
-  modules: ["@nuxt/devtools"],
-
   app: {
     head: {
       title: "Dinosaur Encyclopedia",
-      meta: [
-        { charset: "utf-8" },
-        { name: "viewport", content: "width=device-width, initial-scale=1" },
-      ],
     },
   },
 

--- a/with-nuxt/pages/[name].vue
+++ b/with-nuxt/pages/[name].vue
@@ -1,9 +1,6 @@
 <script setup lang="ts">
-import type { Dino } from "~/types";
-import { useFetch, useRoute } from "nuxt/app";
-
 const route = useRoute();
-const { data: dinosaur } = await useFetch<Dino>(
+const { data: dinosaur } = await useFetch(
   `/api/dinosaurs/${route.params.name}`
 );
 </script>

--- a/with-nuxt/pages/index.vue
+++ b/with-nuxt/pages/index.vue
@@ -1,8 +1,5 @@
 <script setup lang="ts">
-import type { Dino } from "~/types";
-import { useFetch } from "nuxt/app";
-
-const { data: dinosaurs } = await useFetch<Dino[]>("/api/dinosaurs");
+const { data: dinosaurs } = await useFetch("/api/dinosaurs");
 </script>
 
 <template>

--- a/with-nuxt/server/api/dinosaurs.get.ts
+++ b/with-nuxt/server/api/dinosaurs.get.ts
@@ -1,4 +1,3 @@
-import { defineCachedEventHandler } from "#imports";
 import data from "./data.json";
 
 export default defineCachedEventHandler(() => {

--- a/with-nuxt/server/api/dinosaurs/[name].get.ts
+++ b/with-nuxt/server/api/dinosaurs/[name].get.ts
@@ -1,8 +1,6 @@
-import { defineCachedEventHandler } from "#imports";
 import data from "../data.json";
-import { H3Event } from "h3";
 
-export default defineCachedEventHandler((event: H3Event) => {
+export default defineCachedEventHandler((event) => {
     const name = event.context.params?.name;
 
     if (!name) {


### PR DESCRIPTION
a few changes to make the nuxt example more idiomatic

- `<NuxtLayout>` wasn't being used
- `ssr: false` is not required for static generation - rather, it means that there's no HTML rendered
- `viewport` + `charset` are set by default
- `useFetch` is typed so no need to specify the return type
- `useRoute`, `defineCachedEventHandler` and so on are known to TS by the `tsconfig.json`
- `@nuxt/devtools` does not need to be specified; it's enabled automatically