### PR TITLE
Fix typo (porduction => production)

### DIFF
--- a/hello-world/index.html
+++ b/hello-world/index.html
@@ -29,7 +29,7 @@
       </h1>
       <p>
         This little example is being served by <a href="https://deno.com/">Deno</a>.
-        You can run it locally or in porduction on <a href="https://deno.com/deploy">Deno Deploy</a> or other hosting platforms.
+        You can run it locally or in production on <a href="https://deno.com/deploy">Deno Deploy</a> or other hosting platforms.
       </p>
       <ul>
         <li>Run it locally with<code>deno task dev</code></li>

--- a/simple-server/pages/index.html
+++ b/simple-server/pages/index.html
@@ -29,7 +29,7 @@
       </h1>
       <p>
         This little example is being served by <a href="https://deno.com/">Deno</a>.
-        You can run it locally or in porduction on <a href="https://deno.com/deploy">Deno Deploy</a> or other hosting platforms.
+        You can run it locally or in production on <a href="https://deno.com/deploy">Deno Deploy</a> or other hosting platforms.
       </p>
       <ul>
         <li>Run it locally with<code>deno task dev</code></li>


### PR DESCRIPTION
This PR corrects the spelling of "production" in two example projects, `hello-world`, and `simple-server`. 

**Before**
<img width="802" height="260" alt="Screenshot 2025-08-26 at 10 27 34 AM" src="https://github.com/user-attachments/assets/e2f736ad-4b58-4280-8871-b741b553a365" />

**After**
<img width="782" height="263" alt="Screenshot 2025-08-26 at 10 27 53 AM" src="https://github.com/user-attachments/assets/5f3cdd8a-7b34-4270-9fc1-255bf2fadb03" />

Thanks for your work!